### PR TITLE
build: wait for database before initialzing pods

### DIFF
--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -26,7 +26,7 @@ spec:
 
       containers:
         - name: lanchonete-api-container
-          image: vitorrafael/lanchonete-api:sequelize-try-catch
+          image: vitorrafael/lanchonete-api:latest
           env:
             - name: POSTGRES_HOST
               value: "lanchonete-db"

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -11,9 +11,22 @@ spec:
       labels:
         app: lanchonete-api
     spec:
+      initContainers:
+      - name: wait-for-database
+        image: alpine
+        env:
+        - name: DATABASE_HOST
+          value: "lanchonete-db"
+        - name: DATABASE_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: lanchonete-db-config
+              key: POSTGRES_PORT
+        command: ['sh', '-c', 'until nc -z $DATABASE_HOST $DATABASE_PORT; do echo "waiting for database"; sleep 5; done; echo "Database is up!"']
+
       containers:
         - name: lanchonete-api-container
-          image: vitorrafael/lanchonete-api:latest
+          image: vitorrafael/lanchonete-api:sequelize-try-catch
           env:
             - name: POSTGRES_HOST
               value: "lanchonete-db"

--- a/k8s/db/service.yaml
+++ b/k8s/db/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: lanchonete-db
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 5432
   selector:


### PR DESCRIPTION
## 1. O que esse PR faz?
Faz com que o `Deployment` da aplicação só aconteça depois que o banco estiver disponível, assim evitando _restarts_ desnecessários.
