### PR TITLE
feature: create a storageclass

### DIFF
--- a/k8s/db/persistent-volume-claim.yaml
+++ b/k8s/db/persistent-volume-claim.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: lanchonete-db
 spec:
-  storageClassName: manual
+  storageClassName: local-storage
   accessModes:
     - ReadWriteMany
   resources:

--- a/k8s/db/persistent-volume.yaml
+++ b/k8s/db/persistent-volume.yaml
@@ -6,7 +6,8 @@ metadata:
     type: local
     app: lanchonete-db-volume
 spec:
-  storageClassName: manual
+  storageClassName: local-storage
+  persistentVolumeReclaimPolicy: Retain 
   capacity:
     storage: 10Gi
   accessModes:


### PR DESCRIPTION
## 1. O que esse PR faz?
Encontrei um erro ao subir os artefatos k8s no qual a `storageClass` `manual` não estava sendo encontrada, percebi que nos arquivos das aulas o professor criou um artefato **StorageClass**, então repliquei isso no nosso cenário.