### PR TITLE
Add Find Customer By Id

### DIFF
--- a/src/api/CustomersAPI.ts
+++ b/src/api/CustomersAPI.ts
@@ -23,6 +23,19 @@ customersAPIRouter.get("/customers/:cpf", async (req, res) => {
   }
 });
 
+customersAPIRouter.get("/customers/id/:id", async (req, res) => {
+  try {
+    const id = req.params.id;
+    const customerFound = await CustomerController.findCustomerByID(new SequelizeCustomerDataSource(), Number(id));
+    return res.status(200).json(customerFound);
+  } catch (error: any) {
+    if (error instanceof ResourceNotFoundError) {
+      return res.status(404).json({ error: error.message });
+    }
+    return res.status(500).json({ error: error.message });
+  }
+});
+
 customersAPIRouter.post("/customers", async (req, res) => {
   try {
     const { name, cpf, email } = req.body;

--- a/src/api/CustomersAPI.ts
+++ b/src/api/CustomersAPI.ts
@@ -10,9 +10,9 @@ import ResourceNotFoundError from "../core/common/exceptions/ResourceNotFoundErr
 
 const customersAPIRouter = Router();
 
-customersAPIRouter.get("/customers/:cpf", async (req, res) => {
+customersAPIRouter.get("/customers/", async (req, res) => {
   try {
-    const cpf = req.params.cpf;
+    const cpf = req.query.cpf as string;
     const customerFound = await CustomerController.findCustomerByCpf(new SequelizeCustomerDataSource(), cpf);
     return res.status(200).json(customerFound);
   } catch (error: any) {
@@ -23,7 +23,7 @@ customersAPIRouter.get("/customers/:cpf", async (req, res) => {
   }
 });
 
-customersAPIRouter.get("/customers/id/:id", async (req, res) => {
+customersAPIRouter.get("/customers/:id", async (req, res) => {
   try {
     const id = req.params.id;
     const customerFound = await CustomerController.findCustomerByID(new SequelizeCustomerDataSource(), Number(id));

--- a/src/controllers/CustomerController.ts
+++ b/src/controllers/CustomerController.ts
@@ -15,4 +15,10 @@ export default class CustomerController {
     const foundCustomer = await useCase.findByCPF(cpf);
     return CustomerPresenter.adaptCustomerData(foundCustomer);
   }
+
+  public static async findCustomerByID(customerDataSource: CustomerDataSource, id: number): Promise<CustomerResponse> {
+    const useCase = CustomersFactory.makeFindCustomerById(customerDataSource);
+    const foundCustomer = await useCase.findByID(id);
+    return CustomerPresenter.adaptCustomerData(foundCustomer);
+  }
 }

--- a/src/core/common/exceptions/MissingParameterError.ts
+++ b/src/core/common/exceptions/MissingParameterError.ts
@@ -1,0 +1,7 @@
+const message = "Missing parameter '&1'";
+
+export default class MissingParameterError extends Error {
+  constructor(property: string) {
+    super(message.replace("&1", property));
+  }
+}

--- a/src/core/customers/interfaces/FindCustomerById.d.ts
+++ b/src/core/customers/interfaces/FindCustomerById.d.ts
@@ -1,0 +1,5 @@
+import CustomerDTO from "../dto/CustomerDTO";
+
+export default interface FindCustomerById {
+  findByID(id: number): Promise<CustomerDTO>;
+}

--- a/src/core/customers/use-cases/FindCustomerByCpfUseCase.ts
+++ b/src/core/customers/use-cases/FindCustomerByCpfUseCase.ts
@@ -1,3 +1,4 @@
+import MissingParameterError from "../../common/exceptions/MissingParameterError";
 import ResourceNotFoundError from "../../common/exceptions/ResourceNotFoundError";
 import CustomerGateway from "../../interfaces/CustomerGateway";
 import FindCustomerByCpf from "../interfaces/FindCustomerByCpf";
@@ -6,6 +7,8 @@ export default class FindCustomerByCpfUseCase implements FindCustomerByCpf {
   constructor(private customerGateway: CustomerGateway) {}
 
   async findByCPF(cpf: string) {
+    if (!cpf) throw new MissingParameterError("cpf");
+
     const customer = await this.customerGateway.findByCPF(cpf);
     if (!customer) throw new ResourceNotFoundError(ResourceNotFoundError.Resources.Customer, "cpf", cpf);
 

--- a/src/core/customers/use-cases/FindCustomerByIdUseCase.ts
+++ b/src/core/customers/use-cases/FindCustomerByIdUseCase.ts
@@ -1,0 +1,14 @@
+import ResourceNotFoundError from "../../common/exceptions/ResourceNotFoundError";
+import CustomerGateway from "../../interfaces/CustomerGateway";
+import FindCustomerById from "../interfaces/FindCustomerById";
+
+export default class FindCustomerByIdUseCase implements FindCustomerById {
+  constructor(private customerGateway: CustomerGateway) {}
+
+  async findByID(id: number) {
+    const customer = await this.customerGateway.findById(id);
+    if (!customer) throw new ResourceNotFoundError(ResourceNotFoundError.Resources.Customer, "id", id);
+
+    return customer;
+  }
+}

--- a/src/factories/CustomersFactory.ts
+++ b/src/factories/CustomersFactory.ts
@@ -1,7 +1,9 @@
 import CreateCustomer from "../core/customers/interfaces/CreateCustomer";
 import FindCustomerByCpf from "../core/customers/interfaces/FindCustomerByCpf";
+import FindCustomerById from "../core/customers/interfaces/FindCustomerById";
 import CreateCustomerUseCase from "../core/customers/use-cases/CreateCustomerUseCase";
 import FindCustomerByCpfUseCase from "../core/customers/use-cases/FindCustomerByCpfUseCase";
+import FindCustomerByIdUseCase from "../core/customers/use-cases/FindCustomerByIdUseCase";
 
 import CustomerGateway from "../gateways/CustomerGateway";
 import { CustomerDataSource } from "../interfaces/DataSources";
@@ -13,5 +15,9 @@ export class CustomersFactory {
 
   public static makeFindCustomerByCpf(dataSource: CustomerDataSource): FindCustomerByCpf {
     return new FindCustomerByCpfUseCase(new CustomerGateway(dataSource));
+  }
+
+  public static makeFindCustomerById(dataSource: CustomerDataSource): FindCustomerById {
+    return new FindCustomerByIdUseCase(new CustomerGateway(dataSource));
   }
 }

--- a/src/routes/customerRoutes.yaml
+++ b/src/routes/customerRoutes.yaml
@@ -1,11 +1,35 @@
 paths:
-  /customers/{cpf}:
+  /customers/{id}:
+    get:
+      summary: Exibe dados de um cliente pelo ID
+      tags:
+        - Clientes
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID do cliente
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Cliente encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Customer"
+        "404":
+          description: Cliente não encontrado
+        "500":
+          description: Erro interno do servidor
+
+  /customers:
     get:
       summary: Exibe dados de um cliente pelo CPF
       tags:
         - Clientes
       parameters:
-        - in: path
+        - in: query
           name: cpf
           required: true
           description: CPF do cliente
@@ -23,7 +47,7 @@ paths:
         "500":
           description: Erro interno do servidor
 
-  /customers:
+
     post:
       summary: Cria um novo cliente
       tags:

--- a/src/tests/adapters/api/CustomerController.test.ts
+++ b/src/tests/adapters/api/CustomerController.test.ts
@@ -97,7 +97,7 @@ describe("Customer Controller", () => {
     const customerCreated = { ...customer, id: 1, cpf: "123.456.789-09" };
     findByPropertiesStub.resolves([customerCreated]);
 
-    const res = await request(app).get(`/customers/${customer.cpf}`);
+    const res = await request(app).get(`/customers`).query({ cpf: customer.cpf });
 
     expect(res.status).to.equal(200);
     expect(res.body).to.deep.equal(customerCreated);
@@ -105,7 +105,7 @@ describe("Customer Controller", () => {
 
   it("should return error message when client is not found", async () => {
     const cpf = "12345678909";
-    const res = await request(app).get(`/customers/${cpf}`);
+    const res = await request(app).get(`/customers`).query({ cpf });
 
     expect(res.status).to.equal(404);
     expect(res.body).to.deep.equal({ error: new ResourceNotFoundError(ResourceNotFoundError.Resources.Customer, "cpf", cpf).message });
@@ -116,7 +116,37 @@ describe("Customer Controller", () => {
   it("should return error message when an error occurs to search the customer", async () => {
     findByPropertiesStub.rejects();
 
-    const res = await request(app).get("/customers/1234");
+    const res = await request(app).get("/customers").query({ cpf: "1234" });
+
+    expect(res.status).to.equal(500);
+    expect(res.body).to.deep.equal({ error: "Error" });
+    expect(findByPropertiesStub.calledOnce).to.be.true;
+  });
+
+  it("should find customer by id", async () => {
+    const customer = buildCustomer();
+    const customerCreated = { ...customer, id: 1, cpf: "123.456.789-09" };
+    findByPropertiesStub.resolves([customerCreated]);
+
+    const res = await request(app).get(`/customers/1`);
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal(customerCreated);
+  });
+
+  it("should return error message when client is not found", async () => {
+    const id = "2";
+    const res = await request(app).get(`/customers/${id}`);
+    expect(res.status).to.equal(404);
+    expect(res.body).to.deep.equal({ error: new ResourceNotFoundError(ResourceNotFoundError.Resources.Customer, "id", id).message });
+    expect(findByPropertiesStub.called).to.be.true;
+    expect(createStub.called).to.be.false;
+  });
+
+  it("should return error message when an error occurs to search the customer", async () => {
+    findByPropertiesStub.rejects();
+
+    const res = await request(app).get(`/customers/1234`);
 
     expect(res.status).to.equal(500);
     expect(res.body).to.deep.equal({ error: "Error" });
@@ -124,7 +154,7 @@ describe("Customer Controller", () => {
   });
 
   it("should return error message of Route not found when route is invalid", async () => {
-    const res = await request(app).get("/customers/");
+    const res = await request(app).put("/customers/");
 
     expect(res.status).to.equal(404);
     expect(res.body).to.deep.equal({ error: "Route not found" });

--- a/src/tests/core/customer/use-cases/FindCustomerByCpfUseCase.test.ts
+++ b/src/tests/core/customer/use-cases/FindCustomerByCpfUseCase.test.ts
@@ -1,12 +1,12 @@
-import MissingPropertyError from "../../../../core/common/exceptions/MissingPropertyError";
 import ResourceNotFoundError from "../../../../core/common/exceptions/ResourceNotFoundError";
 import FindCustomerByCpfUseCase from "../../../../core/customers/use-cases/FindCustomerByCpfUseCase";
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import MissingParameterError from "../../../../core/common/exceptions/MissingParameterError";
 import CustomerDTO from "../../../../core/customers/dto/CustomerDTO";
-import FakeCustomerGateway from "../../../../gateways/FakeCustomerGateway";
 import CustomerGateway from "../../../../core/interfaces/CustomerGateway";
+import FakeCustomerGateway from "../../../../gateways/FakeCustomerGateway";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -48,6 +48,11 @@ context("Customer Management", () => {
       await customerGateway.create(customerDTO);
 
       await expect(customerManagementUseCase.findByCPF("123")).to.be.eventually.rejectedWith(ResourceNotFoundError);
+    });
+
+    it("should throw an error when cpf is not provided", async () => {
+      const customerManagementUseCase = setupUseCase();
+      await expect(customerManagementUseCase.findByCPF("")).to.be.eventually.rejectedWith(MissingParameterError);
     });
   });
 });

--- a/src/tests/core/customer/use-cases/FindCustomerByIdUseCase.test.ts
+++ b/src/tests/core/customer/use-cases/FindCustomerByIdUseCase.test.ts
@@ -1,0 +1,53 @@
+import MissingPropertyError from "../../../../core/common/exceptions/MissingPropertyError";
+import ResourceNotFoundError from "../../../../core/common/exceptions/ResourceNotFoundError";
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import CustomerDTO from "../../../../core/customers/dto/CustomerDTO";
+import FakeCustomerGateway from "../../../../gateways/FakeCustomerGateway";
+import CustomerGateway from "../../../../core/interfaces/CustomerGateway";
+import FindCustomerByIdUseCase from "../../../../core/customers/use-cases/FindCustomerByIdUseCase";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+let customerGateway: CustomerGateway;
+context("Customer Management", () => {
+  function setupUseCase() {
+    customerGateway = new FakeCustomerGateway();
+
+    return new FindCustomerByIdUseCase(customerGateway);
+  }
+
+  describe("find by ID", () => {
+    it("should find customer by ID", async () => {
+      const customerDTO = new CustomerDTO({
+        name: "Ana",
+        cpf: "123.456.789-01",
+        email: "test@mail.com"
+      });
+
+      const customerManagementUseCase = setupUseCase();
+      const { id } = await customerGateway.create(customerDTO);
+
+      const customerFound = await customerManagementUseCase.findByID(id!);
+
+      expect(customerFound).to.not.be.undefined;
+      expect(customerFound.cpf).to.be.equal(customerDTO.cpf);
+    });
+
+    it("should display an error message when it cannot find the customer", async () => {
+      const customerDTO = new CustomerDTO({
+        name: "Ana",
+        cpf: "123.456.789-01",
+        email: "test@mail.com"
+      });
+
+      const customerManagementUseCase = setupUseCase();
+
+      await customerGateway.create(customerDTO);
+
+      await expect(customerManagementUseCase.findByID(123)).to.be.eventually.rejectedWith(ResourceNotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## 1. O que esse PR faz?
Modifica as APIs de Customer devido a separação dos microserviços.
Implementa a busca de **Customers** por `ID`.
Atualiza a documentação do Swagger para que reflita os novos endpoints.

## 2. Testes
> Coberto pelos testes automatizados

## 3. Importante e observações
Essa modificação é necessária devido as quebras de microserviço, como o Payload de `POST orders` espera um Customer ID e não temos essa informação persistida no domínio de Orders, é necessário buscar ela no domínio de **Customers** (atualmente o monolíto).